### PR TITLE
Iflib buflen changes

### DIFF
--- a/sys/dev/ixgbe/iflib_ix_txrx.c
+++ b/sys/dev/ixgbe/iflib_ix_txrx.c
@@ -54,7 +54,7 @@ static void ixgbe_isc_txd_flush(void *arg, uint16_t txqid, uint32_t pidx);
 static int ixgbe_isc_txd_credits_update(void *arg, uint16_t txqid, uint32_t cidx, bool clear);
 
 static void ixgbe_isc_rxd_refill(void *arg, uint16_t rxqid, uint8_t flid __unused,
-				   uint32_t pidx, uint64_t *paddrs, caddr_t *vaddrs __unused, uint16_t count);
+				   uint32_t pidx, uint64_t *paddrs, caddr_t *vaddrs __unused, uint16_t count, uint16_t buf_len);
 static void ixgbe_isc_rxd_flush(void *arg, uint16_t rxqid, uint8_t flid __unused, uint32_t pidx);
 static int ixgbe_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx);
 static int ixgbe_isc_rxd_pkt_get(void *arg, if_rxd_info_t ri);
@@ -325,7 +325,7 @@ ixgbe_isc_txd_credits_update(void *arg, uint16_t txqid, uint32_t cidx_init, bool
 
 static void
 ixgbe_isc_rxd_refill(void *arg, uint16_t rxqid, uint8_t flid __unused,
-				 uint32_t pidx, uint64_t *paddrs, caddr_t *vaddrs __unused, uint16_t count)
+				 uint32_t pidx, uint64_t *paddrs, caddr_t *vaddrs __unused, uint16_t count, uint16_t buf_len)
 {
 	struct adapter *sc       = arg;
 	struct ix_rx_queue *que     = &sc->rx_queues[rxqid];
@@ -436,6 +436,7 @@ ixgbe_isc_rxd_pkt_get(void *arg, if_rxd_info_t ri)
 		}
 		ri->iri_frags[i].irf_flid = 0;
 		ri->iri_frags[i].irf_idx = cidx;
+		ri->iri_frags[i].irf_len = len;
 		if (++cidx == adapter->shared->isc_nrxd)
 			cidx = 0;
 		i++;

--- a/sys/dev/ixl/iflib_ixl_txrx.c
+++ b/sys/dev/ixl/iflib_ixl_txrx.c
@@ -58,7 +58,7 @@ static void ixl_isc_txd_flush(void *arg, uint16_t txqid, uint32_t pidx);
 static int ixl_isc_txd_credits_update(void *arg, uint16_t qid, uint32_t cidx, bool clear);
 
 static void ixl_isc_rxd_refill(void *arg, uint16_t rxqid, uint8_t flid __unused,
-				   uint32_t pidx, uint64_t *paddrs, caddr_t *vaddrs __unused, uint16_t count);
+				   uint32_t pidx, uint64_t *paddrs, caddr_t *vaddrs __unused, uint16_t count, uint16_t buf_len);
 static void ixl_isc_rxd_flush(void *arg, uint16_t rxqid, uint8_t flid __unused, uint32_t pidx);
 static int ixl_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx);
 static int ixl_isc_rxd_pkt_get(void *arg, if_rxd_info_t ri);
@@ -358,7 +358,7 @@ ixl_isc_txd_credits_update(void *arg, uint16_t qid, uint32_t cidx, bool clear)
  **********************************************************************/
 static void
 ixl_isc_rxd_refill(void *arg, uint16_t rxqid, uint8_t flid __unused,
-				   uint32_t pidx, uint64_t *paddrs, caddr_t *vaddrs __unused, uint16_t count)
+				   uint32_t pidx, uint64_t *paddrs, caddr_t *vaddrs __unused, uint16_t count, uint16_t buf_len)
 
 {
 	struct ixl_vsi		*vsi = arg;
@@ -526,6 +526,7 @@ ixl_isc_rxd_pkt_get(void *arg, if_rxd_info_t ri)
 		}
 		ri->iri_frags[i].irf_flid = 0;
 		ri->iri_frags[i].irf_idx = cidx;
+		ri->iri_frags[i].irf_len = plen;
 		if (++cidx == scctx->isc_ntxd)
 			cidx = 0;
 		i++;

--- a/sys/net/iflib.c
+++ b/sys/net/iflib.c
@@ -1998,8 +1998,13 @@ assemble_segments(iflib_rxq_t rxq, if_rxd_info_t ri)
 		MPASS(sd->ifsd_m != NULL);
 
 		/* Don't include zero-length frags */
-		if (ri->iri_frags[i].irf_len == 0)
+		if (ri->iri_frags[i].irf_len == 0) {
+			/* XXX we can save the cluster here, but not the mbuf */
+			m_init(sd->ifsd_m, M_NOWAIT, MT_DATA, 0);
+			m_free(sd->ifsd_m);
+			sd->ifsd_m = NULL;
 			continue;
+		}
 
 		m = sd->ifsd_m;
 		if (mh == NULL) {

--- a/sys/net/iflib.c
+++ b/sys/net/iflib.c
@@ -1990,14 +1990,19 @@ assemble_segments(iflib_rxq_t rxq, if_rxd_info_t ri)
 	caddr_t cl;
 
 	i = 0;
+	mh = NULL;
 	do {
 		sd = rxd_frag_to_sd(rxq, &ri->iri_frags[i], &cltype, TRUE);
 
 		MPASS(sd->ifsd_cl != NULL);
 		MPASS(sd->ifsd_m != NULL);
 
+		/* Don't include zero-length frags */
+		if (ri->iri_frags[i].irf_len == 0)
+			continue;
+
 		m = sd->ifsd_m;
-		if (i == 0) {
+		if (mh == NULL) {
 			flags = M_PKTHDR|M_EXT;
 			mh = mt = m;
 			padlen = ri->iri_pad;

--- a/sys/net/iflib.c
+++ b/sys/net/iflib.c
@@ -1023,7 +1023,7 @@ iflib_netmap_rxq_init(if_ctx_t ctx, iflib_rxq_t rxq)
 			vaddr = addr = PNMB(na, slot + sj, &paddr);
 			netmap_load_map(na, rxq->ifr_fl[0].ifl_ifdi->idi_tag, sd->ifsd_map, addr);
 			/* Update descriptor and the cached value */
-			ctx->isc_rxd_refill(ctx->ifc_softc, rxq->ifr_id, 0 /* fl_id */, i, &paddr, &vaddr, 1, fl->ifl_buf_size);
+			ctx->isc_rxd_refill(ctx->ifc_softc, rxq->ifr_id, 0 /* fl_id */, i, &paddr, &vaddr, 1, rxq->ifr_fl[0].ifl_buf_size);
 	}
 	/* preserve queue */
 	if (ctx->ifc_ifp->if_capenable & IFCAP_NETMAP) {

--- a/sys/net/iflib.h
+++ b/sys/net/iflib.h
@@ -64,12 +64,14 @@ typedef struct if_int_delay_info  *if_int_delay_info_t;
 typedef struct if_rxd_frag {
 	uint8_t irf_flid;
 	uint16_t irf_idx;
+	uint16_t irf_len;
 } *if_rxd_frag_t;
 
 typedef struct if_rxd_info {
 	/* set by iflib */
 	uint16_t iri_qsidx;		/* qset index */
 	uint16_t iri_vtag;		/* vlan tag - if flag set */
+	/* XXX redundant with the new irf_len field */
 	uint16_t iri_len;		/* packet length */
 	uint16_t iri_cidx;		/* consumer index of cq */
 	struct ifnet *iri_ifp;		/* some drivers >1 interface per softc */

--- a/sys/net/iflib.h
+++ b/sys/net/iflib.h
@@ -162,7 +162,7 @@ typedef struct if_txrx {
 	int (*ift_rxd_available) (void *, uint16_t qsidx, uint32_t pidx);
 	int (*ift_rxd_pkt_get) (void *, if_rxd_info_t ri);
 	void (*ift_rxd_refill) (void * , uint16_t qsidx, uint8_t flidx, uint32_t pidx,
-							uint64_t *paddrs, caddr_t *vaddrs, uint16_t count);
+							uint64_t *paddrs, caddr_t *vaddrs, uint16_t count, uint16_t buf_size);
 	void (*ift_rxd_flush) (void *, uint16_t qsidx, uint8_t flidx, uint32_t pidx);
 	int (*ift_legacy_intr) (void *);
 } *if_txrx_t;


### PR DESCRIPTION
My iflib changes so far...

1) Add a buffer length parameter to the _isc_rxd_refill() since the buffer size _may_ be smaller than the  isc_max_frame_size (if greater than MJUM16BYTES) and there's no reason for the driver to avoid using the whole buffer.

2) Exclude zero-length mbufs from assembled chains.  This allows us to reuse the cluster.

3) Don't break up TX mbuf chains as this breaks tcpdump, only capturing the first segment.  This means we can't use m_freem() to free the whole chain and have to use m_free() on each mbuf... we already called m_freem() on every individual mbuf anyway after breaking them up.
