### PR TITLE
Optimize _isc_rxd_available() by passing budget

### DIFF
--- a/sys/dev/e1000/em_txrx.c
+++ b/sys/dev/e1000/em_txrx.c
@@ -19,7 +19,8 @@ static int em_isc_txd_credits_update(void *arg, uint16_t txqid, uint32_t cidx_in
 static void em_isc_rxd_refill(void *arg, uint16_t rxqid, uint8_t flid __unused,
 			      uint32_t pidx, uint64_t *paddrs, caddr_t *vaddrs __unused, uint16_t count, uint16_t buflen __unused);
 static void em_isc_rxd_flush(void *arg, uint16_t rxqid, uint8_t flid __unused, uint32_t pidx);
-static int em_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx);
+static int em_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx,
+				int budget);
 static int em_isc_rxd_pkt_get(void *arg, if_rxd_info_t ri);
 static void em_receive_checksum(uint32_t status, if_rxd_info_t ri);
 
@@ -475,7 +476,7 @@ em_isc_rxd_flush(void *arg, uint16_t rxqid, uint8_t flid __unused, uint32_t pidx
 }
 
 static int
-em_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx)
+em_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx, int budget)
 {
        	struct adapter *sc         = arg;
 	if_softc_ctx_t scctx = sc->shared;
@@ -487,7 +488,7 @@ em_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx)
 
         device_printf(iflib_get_dev(sc->ctx), "em_isc_rxd_available called\n"); 
 	
-	for (cnt = 0, i = idx; cnt < scctx->isc_nrxd;) {
+	for (cnt = 0, i = idx; cnt < scctx->isc_nrxd && cnt < budget;) {
 		rxd = &rxr->rx_base[i];
 		staterr = le32toh(rxd->wb.upper.status_error);
                 device_printf(iflib_get_dev(sc->ctx), "Count %d\n", cnt); 

--- a/sys/dev/e1000/igb_txrx.c
+++ b/sys/dev/e1000/igb_txrx.c
@@ -18,7 +18,8 @@ static int igb_isc_txd_credits_update(void *arg, uint16_t txqid, uint32_t cidx, 
 static void igb_isc_rxd_refill(void *arg, uint16_t rxqid, uint8_t flid __unused,
 			       uint32_t pidx, uint64_t *paddrs, caddr_t *vaddrs __unused, uint16_t count, uint16_t buf_len __unused);
 static void igb_isc_rxd_flush(void *arg, uint16_t rxqid, uint8_t flid __unused, uint32_t pidx);
-static int igb_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx);
+static int igb_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx,
+				 int budget);
 static int igb_isc_rxd_pkt_get(void *arg, if_rxd_info_t ri);
 
 static int igb_tx_ctx_setup(struct tx_ring *txr, if_pkt_info_t pi, u32 *cmd_type_len, u32 *olinfo_status);
@@ -401,7 +402,7 @@ static void igb_isc_rxd_flush(void *arg, uint16_t rxqid, uint8_t flid __unused, 
          E1000_WRITE_REG(&sc->hw, E1000_RDT(rxr->me), pidx);
 }
 
-static int igb_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx)
+static int igb_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx, int budget)
 {
 	struct adapter *sc           = arg;
 	if_softc_ctx_t scctx         = sc->shared; 
@@ -411,7 +412,7 @@ static int igb_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx)
 	u32                      staterr = 0;
 	int                      cnt, i, iter;
 
-	for (iter = cnt = 0, i = idx; iter < scctx->isc_nrxd;) {
+	for (iter = cnt = 0, i = idx; iter < scctx->isc_nrxd && iter < budget;) {
 		rxd = &rxr->rx_base[i];
 		staterr = le32toh(rxd->wb.upper.status_error);	
 		

--- a/sys/dev/ixgbe/iflib_ix_txrx.c
+++ b/sys/dev/ixgbe/iflib_ix_txrx.c
@@ -56,7 +56,8 @@ static int ixgbe_isc_txd_credits_update(void *arg, uint16_t txqid, uint32_t cidx
 static void ixgbe_isc_rxd_refill(void *arg, uint16_t rxqid, uint8_t flid __unused,
 				   uint32_t pidx, uint64_t *paddrs, caddr_t *vaddrs __unused, uint16_t count, uint16_t buf_len);
 static void ixgbe_isc_rxd_flush(void *arg, uint16_t rxqid, uint8_t flid __unused, uint32_t pidx);
-static int ixgbe_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx);
+static int ixgbe_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx,
+				   int budget);
 static int ixgbe_isc_rxd_pkt_get(void *arg, if_rxd_info_t ri);
 
 static void ixgbe_rx_checksum(u32 staterr, if_rxd_info_t ri, u32 ptype);
@@ -351,7 +352,7 @@ ixgbe_isc_rxd_flush(void *arg, uint16_t rxqid, uint8_t flid __unused, uint32_t p
 }
 
 static int
-ixgbe_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx)
+ixgbe_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx, int budget)
 {
 	struct adapter *sc       = arg;
 	struct ix_rx_queue *que     = &sc->rx_queues[rxqid];
@@ -361,7 +362,7 @@ ixgbe_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx)
 	int                      cnt, i, nrxd;
 
 	nrxd = sc->shared->isc_nrxd;
-	for (cnt = 0, i = idx; cnt < nrxd-1;) {
+	for (cnt = 0, i = idx; cnt < nrxd-1 && cnt < budget;) {
 		rxd = &rxr->rx_base[i];
 		staterr = le32toh(rxd->wb.upper.status_error);
 

--- a/sys/dev/ixl/iflib_ixl_txrx.c
+++ b/sys/dev/ixl/iflib_ixl_txrx.c
@@ -60,7 +60,8 @@ static int ixl_isc_txd_credits_update(void *arg, uint16_t qid, uint32_t cidx, bo
 static void ixl_isc_rxd_refill(void *arg, uint16_t rxqid, uint8_t flid __unused,
 				   uint32_t pidx, uint64_t *paddrs, caddr_t *vaddrs __unused, uint16_t count, uint16_t buf_len);
 static void ixl_isc_rxd_flush(void *arg, uint16_t rxqid, uint8_t flid __unused, uint32_t pidx);
-static int ixl_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx);
+static int ixl_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx,
+				 int budget);
 static int ixl_isc_rxd_pkt_get(void *arg, if_rxd_info_t ri);
 
 extern int ixl_intr(void *arg);
@@ -383,7 +384,7 @@ ixl_isc_rxd_flush(void * arg, uint16_t rxqid, uint8_t flid __unused, uint32_t pi
 }
 
 static int
-ixl_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx)
+ixl_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx, int budget)
 {
 	struct ixl_vsi *vsi = arg;
 	struct rx_ring *rxr = &vsi->rx_queues[rxqid].rxr;
@@ -393,7 +394,7 @@ ixl_isc_rxd_available(void *arg, uint16_t rxqid, uint32_t idx)
 	int cnt, i, mask;
 
 	mask = vsi->shared->isc_nrxd-1;
-	for (cnt = 0, i = idx; cnt < vsi->shared->isc_nrxd;) {
+	for (cnt = 0, i = idx; cnt < vsi->shared->isc_nrxd && cnt < budget;) {
 		cur = &rxr->rx_base[i];
 		qword = le64toh(cur->wb.qword1.status_error_len);
 		status = (qword & I40E_RXD_QW1_STATUS_MASK)

--- a/sys/net/iflib.c
+++ b/sys/net/iflib.c
@@ -49,6 +49,7 @@ __FBSDID("$FreeBSD$");
 #include <sys/sysctl.h>
 #include <sys/syslog.h>
 #include <sys/taskqueue.h>
+#include <sys/limits.h>
 
 
 #include <net/if.h>
@@ -606,7 +607,7 @@ static void iflib_tx_structures_free(if_ctx_t ctx);
 static void iflib_rx_structures_free(if_ctx_t ctx);
 static int iflib_queues_alloc(if_ctx_t ctx);
 static int iflib_tx_credits_update(if_ctx_t ctx, iflib_txq_t txq);
-static int iflib_rxd_avail(if_ctx_t ctx, iflib_rxq_t rxq, int cidx);
+static int iflib_rxd_avail(if_ctx_t ctx, iflib_rxq_t rxq, int cidx, int budget);
 static int iflib_qset_structures_setup(if_ctx_t ctx);
 static int iflib_msix_init(if_ctx_t ctx);
 static int iflib_legacy_setup(if_ctx_t ctx, driver_filter_t filter, void *filterarg, int *rid, char *str);
@@ -877,7 +878,7 @@ iflib_netmap_rxsync(struct netmap_kring *kring, int flags)
 		for (fl = rxq->ifr_fl, i = 0; i < rxq->ifr_nfl; i++, fl++) {
 			nic_i = fl->ifl_cidx;
 			nm_i = netmap_idx_n2k(kring, nic_i);
-			avail = ctx->isc_rxd_available(ctx->ifc_softc, kring->ring_id, nic_i);
+			avail = ctx->isc_rxd_available(ctx->ifc_softc, kring->ring_id, nic_i, INT_MAX);
 			for (n = 0; avail > 0; n++, avail--) {
 				error = ctx->isc_rxd_pkt_get(ctx->ifc_softc, &ri);
 				if (error)
@@ -2103,7 +2104,7 @@ iflib_rxeof(iflib_rxq_t rxq, int budget)
 		cidxp = &rxq->ifr_cq_cidx;
 	else
 		cidxp = &rxq->ifr_fl[0].ifl_cidx;
-	if ((avail = iflib_rxd_avail(ctx, rxq, *cidxp)) == 0) {
+	if ((avail = iflib_rxd_avail(ctx, rxq, *cidxp, budget)) == 0) {
 		for (i = 0, fl = &rxq->ifr_fl[0]; i < sctx->isc_nfl; i++, fl++)
 			__iflib_fl_refill_lt(ctx, fl, budget + 8);
 		DBG_COUNTER_INC(rx_unavail);
@@ -2143,7 +2144,7 @@ iflib_rxeof(iflib_rxq_t rxq, int budget)
 		/* will advance the cidx on the corresponding free lists */
 		m = iflib_rxd_pkt_get(rxq, &ri);
 		if (avail == 0 && budget_left)
-			avail = iflib_rxd_avail(ctx, rxq, *cidxp);
+			avail = iflib_rxd_avail(ctx, rxq, *cidxp, budget_left);
 
 		if (__predict_false(m == NULL)) {
 			DBG_COUNTER_INC(rx_mbuf_null);
@@ -2186,7 +2187,9 @@ iflib_rxeof(iflib_rxq_t rxq, int budget)
 #if defined(INET6) || defined(INET)
 	tcp_lro_flush_all(&rxq->ifr_lc);
 #endif
-	return (iflib_rxd_avail(ctx, rxq, *cidxp));
+	if (avail)
+		return true;
+	return (iflib_rxd_avail(ctx, rxq, *cidxp, 1));
 }
 
 #define M_CSUM_FLAGS(m) ((m)->m_pkthdr.csum_flags)
@@ -4515,10 +4518,11 @@ iflib_tx_credits_update(if_ctx_t ctx, iflib_txq_t txq)
 }
 
 static int
-iflib_rxd_avail(if_ctx_t ctx, iflib_rxq_t rxq, int cidx)
+iflib_rxd_avail(if_ctx_t ctx, iflib_rxq_t rxq, int cidx, int budget)
 {
 
-	return (ctx->isc_rxd_available(ctx->ifc_softc, rxq->ifr_id, cidx));
+	return (ctx->isc_rxd_available(ctx->ifc_softc, rxq->ifr_id, cidx,
+	    budget));
 }
 
 void

--- a/sys/net/iflib.h
+++ b/sys/net/iflib.h
@@ -159,7 +159,8 @@ typedef struct if_txrx {
 	void (*ift_txd_flush) (void *, uint16_t, uint32_t);
 	int (*ift_txd_credits_update) (void *, uint16_t, uint32_t, bool);
 
-	int (*ift_rxd_available) (void *, uint16_t qsidx, uint32_t pidx);
+	int (*ift_rxd_available) (void *, uint16_t qsidx, uint32_t pidx,
+	    int budget);
 	int (*ift_rxd_pkt_get) (void *, if_rxd_info_t ri);
 	void (*ift_rxd_refill) (void * , uint16_t qsidx, uint8_t flidx, uint32_t pidx,
 							uint64_t *paddrs, caddr_t *vaddrs, uint16_t count, uint16_t buf_size);


### PR DESCRIPTION
Pass the budget to _isc_rxd_available() which allows the function to return
early if it finds "enough" descriptions.

Also, don't call _isc_rxd_available() if we already know that we have enough.
